### PR TITLE
Ensure that debug setting doesn't default to true in production

### DIFF
--- a/goodreads_history/settings.py
+++ b/goodreads_history/settings.py
@@ -33,7 +33,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
 
 ALLOWED_HOSTS = [
     "localhost",


### PR DESCRIPTION
For some reason, debug already appears to be false in production, but I can't tell why and that worries me.